### PR TITLE
add support for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,29 @@ $> docker pull cturra/ntp
 
 # run ntp
 $> docker run --name=ntp             \
-              --restart=always       \
+              --restart=on-failure:2 \
               --detach=true          \
               --publish=123:123/udp  \
               --cap-add=SYS_RESOURCE \
               --cap-add=SYS_TIME     \
               cturra/ntp
 ```
+
+
+Building and Running with Docker Compose
+---
+Using the docker-compose.yml file included in this git repo, you can build the container yourself (should you choose to).
+*Note: this docker-compose files uses the `3.4` compose format, which requires Docker Engine release 17.09.0+
+
+```
+# build ntp
+$> docker-compose build ntp
+
+# run ntp
+$> docker-compose up -d ntp
+
+# (optional) check the ntp logs
+$> docker-compose logs ntp
 
 
 Building and Running with Docker Engine

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $> docker-compose up -d ntp
 
 # (optional) check the ntp logs
 $> docker-compose logs ntp
+```
 
 
 Building and Running with Docker Engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.4'
+
+services:
+  ntp:
+    build: .
+    image: cturra/ntp:latest
+    container_name: ntp
+    restart: on-failure:2
+    ports:
+      - 123:123/udp
+    cap_add:
+      - SYS_RESOURCE
+      - SYS_TIME

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ function check_container() {
 function start_container() {
   $DOCKER run --name=${CONTAINER_NAME}         \
               --detach=true                    \
-              --restart=always                 \
+              --restart=on-failure:2           \
               --publish=123:123/udp            \
               ${DOCKER_OPTS}                   \
               ${IMAGE_NAME}:latest > /dev/null


### PR DESCRIPTION
this update includes the docker-compose file and updated README for instructions on how to use it.

also changed the restart policy from `always` to `on-failure:2`. this will ensure that if there is indeed an error when starting pid1, it will only try to start the container 2 times before stopping (instead of forever).