### PR TITLE
Use new --no-cache flag instead of manually updating and deleting cache

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ bug reports and code to this ntp docker project:
 
  - Chris Turra       => https://github.com/cturra
  - Nicolas Innocenti => https://github.com/nicoinn
+ - Richard Coleman   => https://github.com/microbug
 
 
 Thanks for your contributions!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:latest
 
+# install openntp
 RUN apk add --no-cache openntpd
 
 # use custom ntpd config file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM alpine:latest
 
-RUN apk update       \
- && apk add openntpd \
- && rm -rf /var/cache/apk/*
+RUN apk add --no-cache openntpd
 
 # use custom ntpd config file
 COPY assets/ntpd.conf /etc/ntpd.conf


### PR DESCRIPTION
See [alpine usage](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache):

> As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:
> 
> [...]
> 
> This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.

Current `alpine:latest` version is 3.7.