### PR TITLE
adding SYS_CAP_NICE to fix permission issue with openntpd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
     ports:
       - 123:123/udp
     cap_add:
+      - SYS_NICE
       - SYS_RESOURCE
       - SYS_TIME

--- a/vars
+++ b/vars
@@ -8,4 +8,4 @@ IMAGE_NAME="cturra/ntp"
 CONTAINER_NAME="ntp"
 
 # any additional docker run options you may want.
-DOCKER_OPTS="--cap-add SYS_RESOURCE --cap-add SYS_TIME"
+DOCKER_OPTS="--cap-add SYS_NICE --cap-add SYS_RESOURCE --cap-add SYS_TIME"


### PR DESCRIPTION
without this, openntpd returns the following error during startup:
```
ntpd: can't set priority: Permission denied
```

i tracked down a bug that suggests this has been fixed, but i see the same issues without `SYS_CAP_NICE`.

  => https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=855917

for future reference, here is the openntpd package version...
```
/ # apk info openntpd
openntpd-6.2_p3-r0 description:
Lightweight NTP server ported from OpenBSD

openntpd-6.2_p3-r0 webpage:
http://www.openntpd.org/

openntpd-6.2_p3-r0 installed size:
143360
```