### PR TITLE
changing restart policy from on-failure => always

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $> docker pull cturra/ntp
 
 # run ntp
 $> docker run --name=ntp             \
-              --restart=on-failure:2 \
+              --restart=always       \
               --detach=true          \
               --publish=123:123/udp  \
               --cap-add=SYS_NICE     \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     image: cturra/ntp:latest
     container_name: ntp
-    restart: on-failure:2
+    restart: always
     ports:
       - 123:123/udp
     cap_add:

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ function check_container() {
 function start_container() {
   $DOCKER run --name=${CONTAINER_NAME}         \
               --detach=true                    \
-              --restart=on-failure:2           \
+              --restart=always                 \
               --publish=123:123/udp            \
               ${DOCKER_OPTS}                   \
               ${IMAGE_NAME}:latest > /dev/null


### PR DESCRIPTION
this was changed because when the docker host is restarted, the ntp container will not start automatically since the container did not exit due to an error.

from the docker documentation:
* `on-failure`: Restart the container if it exits due to an error, which manifests as a non-zero exit code.
* `always`: Always restart the container if it stops.

ref: https://docs.docker.com/config/containers/start-containers-automatically/