### PR TITLE
adding HEALTHCHECK to tell docker how to test container health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ COPY assets/ntpd.conf /etc/ntpd.conf
 # ntp port
 EXPOSE 123/udp
 
+# let docker know how to test container health
+HEALTHCHECK CMD ntpctl -s status || exit 1
+
 # start ntpd in the foreground
 ENTRYPOINT [ "/usr/sbin/ntpd", "-v", "-d", "-s" ]


### PR DESCRIPTION
this instructs docker how to validate the health of the container.

 => https://docs.docker.com/engine/reference/builder/#healthcheck


example from my local environment:
```
$> docker ps --filter "name=ntp"
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                   PORTS                  NAMES
a99bf06072ed        cturra/ntp:latest   "/usr/sbin/ntpd -v -…"   3 minutes ago       Up 3 minutes (healthy)   0.0.0.0:123->123/udp   ntp
```