### PR TITLE
startup script will now strip quotes from ntp server names

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ like to use one or more different NTP server(s), you can pass this container an 
 environment variable. This can be done by updating the [vars](vars), [docker-compose.yml](docker-compose.yml)
 files or manually passing `--env=NTP_SERVERS="..."` to `docker run`.
 
-Below are some examples of how to configure common NTP Servers. If you're using the `docker-compose`
-configuration, do not use quotes (`"`) around the ntp server list.
+Below are some examples of how to configure common NTP Servers.
 
-Do note, to configure more than one server, you must use a comma delimited list WITHOUT spaces. 
+Do note, to configure more than one server, you must use a comma delimited list WITHOUT spaces.
 
 ```
 # (default) cloudflare

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -28,7 +28,8 @@ if [ -z ${NTP_SERVERS} ]; then
 elif [ $(echo ${#NTP_SERVERS}) > 0 ]; then
   IFS=","
   for n in $NTP_SERVERS; do
-    echo "server $n" >> ${NTP_CONF_FILE}
+    # strip any quotes found before or after ntp server
+    echo "server "${n//\"}"" >> ${NTP_CONF_FILE}
   done
 
 # NTP_SERVERS environment variable is present, but doesn't contain ntp servers, so


### PR DESCRIPTION
this will address configurations that include quotes in docker-compose files like found in issue #14.

using the issue noted above, here is how this update addresses the previously reported issue:

docker-compose.yml config:
```
- NTP_SERVERS="ntp1.aliyun.com,ntp2.aliyun.com,ntp3.aliyun.com,ntp4.aliyun.com,ntp5.aliyun.com,ntp6.aliyun.com,ntp7.aliyun.com"
```

BEFORE this change:
```
$> docker exec -ti ntp cat /etc/ntpd.conf| grep server
# time servers provided by NTP_SERVER environment variables.
server "ntp1.aliyun.com
server ntp2.aliyun.com
server ntp3.aliyun.com
server ntp4.aliyun.com
server ntp5.aliyun.com
server ntp6.aliyun.com
server ntp7.aliyun.com"
```

AFTER this change:
```
$> docker exec -ti ntp cat /etc/ntpd.conf| grep server
# time servers provided by NTP_SERVER environment variables.
server ntp1.aliyun.com
server ntp2.aliyun.com
server ntp3.aliyun.com
server ntp4.aliyun.com
server ntp5.aliyun.com
server ntp6.aliyun.com
server ntp7.aliyun.com
```
