### PR TITLE
Don't check Chrony PID

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ The following awesome folks have contributed ideas,
 bug reports and code to this ntp docker project:
 
  - Chris Turra       => https://github.com/cturra
+ - Clément Péron     => https://github.com/clementperon
  - Nicolas Innocenti => https://github.com/nicoinn
  - Richard Coleman   => https://github.com/microbug
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -9,6 +9,9 @@ mv -f /etc/chrony/chrony.conf /etc/chrony/chrony.conf.bak
 # update permissions on /var/lib/chrony directory
 chown -R chrony:chrony /var/lib/chrony
 
+# remove previous pid file if it exist
+rm -f /var/run/chrony/chronyd.pid
+
 ## dynamically populate chrony config file.
 {
   echo "# https://github.com/cturra/docker-ntp"


### PR DESCRIPTION
If the docker is stopped and the PID is still present chrony will restart with a warning message :
```
2020-07-07T10:26:48Z chronyd version 3.5 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP -SCFILTER +SIGND +ASYNCDNS -SECHASH +IPV6 -DEBUG)
2020-07-07T10:26:48Z Fatal error : Another chronyd may already be running (pid=9), check /var/run/chrony/chronyd.pid
```

Remove PID file at startup