### PR TITLE
multi-architecture build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## Supported Architectures:
+
+Architectures officially supported by this Docker container:
+
+![Linux x86-64](//img.shields.io/badge/linux/amd64-yellowgreen)
+![ARMv8 64-bit](//img.shields.io/badge/linux/arm64-yellowgreen)
+![IBM POWER8](//img.shields.io/badge/linux/ppc64le-yellowgreen)
+![IBM Z Systems](//img.shields.io/badge/linux/s390x-yellowgreen)
+![Linux x86/i686](//img.shields.io/badge/linux/386-yellowgreen)
+![ARMv7 32-bit](//img.shields.io/badge/linux/arm/v7-yellowgreen)
+![ARMv6 32-bit](//img.shields.io/badge/linux/arm/v6-yellowgreen)
+
+
 ## About this container
 
 [![Docker Build Status](https://img.shields.io/docker/build/cturra/ntp.svg)](https://hub.docker.com/r/cturra/ntp/)

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -28,5 +28,3 @@ else
                        --tag ${IMAGE_NAME} \
                        --push .
 fi
-
-

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# grab global variables
+source vars
+
+DOCKER=$(which docker)
+BUILD_INST=${CONTAINER_NAME}"-builder"
+
+## requirements:
+# - docker buildx plugin (https://docs.docker.com/buildx/working-with-buildx/)
+if [[ ! -f ~/.docker/cli-plugins/buildx ]]; then
+  echo "[ERROR] docker buildx plugin not found!"
+  echo "        => https://github.com/docker/buildx/"
+  exit 1
+
+else
+  # check if build instance (BUILD_INST) is present
+  $DOCKER buildx ls | grep ${BUILD_INST} 2>&1 /dev/null
+  if [ $? -eq 1 ]; then
+    # not found. let's create it
+    $DOCKER run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    $DOCKER buildx create --name ${BUILD_INST} --driver docker-container --use
+  fi
+
+  # finally, let's build the ntp container
+  $DOCKER buildx use ${BUILD_INST}
+  $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
+                       --tag ${IMAGE_NAME} \
+                       --push .
+fi
+
+


### PR DESCRIPTION
i've been sitting on this for a bit, but figured it was time to officially wrap this work into the main repo. this change adds a
new build script for building/pushing multi-architecture builds to docker hub. currently supported are:

 * linux/amd64
 * linux/arm64
 * linux/ppc64le
 * linux/s390x
 * linux/386
 * linux/arm/v7
 * linux/arm/v6