### PR TITLE
Streamline docker build and startup script

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ bug reports and code to this ntp docker project:
  - Clément Péron     => https://github.com/clementperon
  - Nicolas Innocenti => https://github.com/nicoinn
  - Richard Coleman   => https://github.com/microbug
+ - Simon Rupf        => https://github.com/simonrupf
 
 
 Thanks for your contributions!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:latest
 
 # install chrony
-RUN apk add --no-cache chrony
+RUN apk add --no-cache chrony && \
+    rm /etc/chrony/chrony.conf
 
 # script to configure/startup chrony (ntp)
 COPY assets/startup.sh /opt/startup.sh
@@ -12,5 +13,7 @@ EXPOSE 123/udp
 # let docker know how to test container health
 HEALTHCHECK CMD chronyc tracking || exit 1
 
+VOLUME /etc/chrony /var/lib/chrony /var/run/chrony
+
 # start chronyd in the foreground
-ENTRYPOINT [ "/bin/sh", "/opt/startup.sh" ]
+ENTRYPOINT [ "/opt/startup.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ HEALTHCHECK CMD chronyc tracking || exit 1
 VOLUME /etc/chrony /var/lib/chrony /var/run/chrony
 
 # start chronyd in the foreground
-ENTRYPOINT [ "/opt/startup.sh" ]
+ENTRYPOINT [ "/bin/sh", "/opt/startup.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,5 @@ EXPOSE 123/udp
 # let docker know how to test container health
 HEALTHCHECK CMD chronyc tracking || exit 1
 
-VOLUME /etc/chrony /run/chrony /var/lib/chrony
-
 # start chronyd in the foreground
 ENTRYPOINT [ "/bin/sh", "/opt/startup.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:latest
 
 # install chrony
-RUN apk add --no-cache chrony && \
-    rm /etc/chrony/chrony.conf
+RUN apk add --no-cache chrony
 
 # script to configure/startup chrony (ntp)
 COPY assets/startup.sh /opt/startup.sh
@@ -13,7 +12,7 @@ EXPOSE 123/udp
 # let docker know how to test container health
 HEALTHCHECK CMD chronyc tracking || exit 1
 
-VOLUME /etc/chrony /var/lib/chrony /var/run/chrony
+VOLUME /etc/chrony /run/chrony /var/lib/chrony
 
 # start chronyd in the foreground
 ENTRYPOINT [ "/bin/sh", "/opt/startup.sh" ]

--- a/README.md
+++ b/README.md
@@ -33,12 +33,23 @@ Pull and run -- it's this simple.
 $> docker pull cturra/ntp
 
 # run ntp
-$> docker run --name=ntp             \
-              --restart=always       \
-              --detach=true          \
-              --publish=123:123/udp  \
-              --cap-add=SYS_TIME     \
-              --read-only            \
+$> docker run --name=ntp            \
+              --restart=always      \
+              --detach              \
+              --publish=123:123/udp \
+              --cap-add=SYS_TIME    \
+              cturra/ntp
+
+# OR run ntp with higher security (default behaviour of run.sh and docker-compose).
+$> docker run --name=ntp                           \
+              --restart=always                     \
+              --detach                             \
+              --publish=123:123/udp                \
+              --cap-add=SYS_TIME                   \
+              --read-only                          \
+              --tmpfs=/etc/chrony:rw,mode=1750     \
+              --tmpfs=/run/chrony:rw,mode=1750     \
+              --tmpfs=/var/lib/chrony:rw,mode=1750 \
               cturra/ntp
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $> docker run --name=ntp             \
               --detach=true          \
               --publish=123:123/udp  \
               --cap-add=SYS_TIME     \
+              --read-only            \
               cturra/ntp
 ```
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -3,11 +3,15 @@
 DEFAULT_NTP="time.cloudflare.com"
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 
-# update permissions on /var/lib/chrony directory
-chown -R chrony:chrony /var/lib/chrony
+# update permissions on chrony directories
+chown -R chrony:chrony /run/chrony /var/lib/chrony
+chmod o-rx /run/chrony
 
 # remove previous pid file if it exist
 rm -f /var/run/chrony/chronyd.pid
+
+## remove chrony config file.
+rm ${CHRONY_CONF_FILE}
 
 ## dynamically populate chrony config file.
 {

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -52,4 +52,4 @@ fi
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-/usr/sbin/chronyd -d -s
+exec /usr/sbin/chronyd -d -s

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -7,11 +7,11 @@ CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 chown -R chrony:chrony /run/chrony /var/lib/chrony
 chmod o-rx /run/chrony
 
-# remove previous pid file if it exist
-rm -f /var/run/chrony/chronyd.pid
-
 ## remove chrony config file.
 rm ${CHRONY_CONF_FILE}
+
+# remove previous pid file if it exist
+rm -f /var/run/chrony/chronyd.pid
 
 ## dynamically populate chrony config file.
 {

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -21,23 +21,15 @@ rm -f /var/run/chrony/chronyd.pid
 
 
 # NTP_SERVERS environment variable is not present, so populate with default server
-if [ -z ${NTP_SERVERS} ]; then
-  echo "server ${DEFAULT_NTP} iburst" >> ${CHRONY_CONF_FILE}
-
-# check if list of ntp servers provided in NTP_SERVERS environment variable
-# are present and is of greater than length 0.
-elif [ $(echo ${#NTP_SERVERS}) > 0 ]; then
-  IFS=","
-  for N in $NTP_SERVERS; do
-    # strip any quotes found before or after ntp server
-    echo "server "${N//\"}" iburst" >> ${CHRONY_CONF_FILE}
-  done
-
-# NTP_SERVERS environment variable is present, but doesn't contain ntp servers, so
-# populate with a default server.
-else
-  echo "server ${DEFAULT_NTP} iburst" >> ${CHRONY_CONF_FILE}
+if [ -z "${NTP_SERVERS}" ]; then
+  NTP_SERVERS="${DEFAULT_NTP}"
 fi
+
+IFS=","
+for N in $NTP_SERVERS; do
+  # strip any quotes found before or after ntp server
+  echo "server "${N//\"}" iburst" >> ${CHRONY_CONF_FILE}
+done
 
 # final bits for the config file
 {

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -7,9 +7,6 @@ CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 chown -R chrony:chrony /run/chrony /var/lib/chrony
 chmod o-rx /run/chrony
 
-## remove chrony config file.
-rm ${CHRONY_CONF_FILE}
-
 # remove previous pid file if it exist
 rm -f /var/run/chrony/chronyd.pid
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -3,9 +3,6 @@
 DEFAULT_NTP="time.cloudflare.com"
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 
-# move aside original config file
-mv -f /etc/chrony/chrony.conf /etc/chrony/chrony.conf.bak
-
 # update permissions on /var/lib/chrony directory
 chown -R chrony:chrony /var/lib/chrony
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,11 @@ services:
     ports:
       - 123:123/udp
     cap_add:
-      - SYS_NICE
-      - SYS_RESOURCE
       - SYS_TIME
     read_only: true
+    tmpfs:
+      - /etc/chrony:rw,mode=1750
+      - /run/chrony:rw,mode=1750
+      - /var/lib/chrony:rw,mode=1750
     environment:
       - NTP_SERVERS=time.cloudflare.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,6 @@ services:
       - SYS_NICE
       - SYS_RESOURCE
       - SYS_TIME
+    read_only: true
     environment:
       - NTP_SERVERS=time.cloudflare.com

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ function start_container() {
               --restart=always                 \
               --publish=123:123/udp            \
               --env=NTP_SERVERS=${NTP_SERVERS} \
+              --read-only                      \
               ${DOCKER_OPTS}                   \
               ${IMAGE_NAME}:latest > /dev/null
 }

--- a/run.sh
+++ b/run.sh
@@ -12,13 +12,17 @@ function check_container() {
 
 # function to start new docker container
 function start_container() {
-  $DOCKER run --name=${CONTAINER_NAME}         \
-              --detach=true                    \
-              --restart=always                 \
-              --publish=123:123/udp            \
-              --env=NTP_SERVERS=${NTP_SERVERS} \
-              --read-only                      \
-              ${DOCKER_OPTS}                   \
+  $DOCKER run --name=${CONTAINER_NAME}             \
+              --detach=true                        \
+              --restart=always                     \
+              --publish=123:123/udp                \
+              --env=NTP_SERVERS=${NTP_SERVERS}     \
+              --cap-add=SYS_TIME                   \
+              --read-only=true                     \
+              --tmpfs=/etc/chrony:rw,mode=1750     \
+              --tmpfs=/run/chrony:rw,mode=1750     \
+              --tmpfs=/var/lib/chrony:rw,mode=1750 \
+              ${DOCKER_OPTS}                       \
               ${IMAGE_NAME}:latest > /dev/null
 }
 

--- a/vars
+++ b/vars
@@ -7,11 +7,11 @@
 IMAGE_NAME="cturra/ntp"
 CONTAINER_NAME="ntp"
 
-# any additional docker run options you may want.
-DOCKER_OPTS="--cap-add SYS_TIME"
-
 # (optional) define ntp server(s) to use
 # if none are provided a default is chosen
 # ntp server list must: be comma delimited and NOT contain spaces
 # NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com"
 NTP_SERVERS="time.cloudflare.com"
+
+# (optional) additional docker run options you may want
+DOCKER_OPTS=""


### PR DESCRIPTION
The following are a number of minor improvements that I'd like to propose for inclusion:
- `exec` the the chronyd process - this replaces the shell PID 0 process with chronyd and let's it receive signals from the container environment
- ~marked `VOLUME`s~ tmpfs - this allows the container to be run with `--read-only` image, slightly decreasing startup time and hardening the container
- changed test from `[ -z ${NTP_SERVERS} ]` to `[ -z "${NTP_SERVERS}" ]` - so it actually works and the subsequent logic can be simplified
- ~removed `/bin/sh` from entrypoint - the script is executable and has a she-bang, so it doesn't not need to be repeated here~

Please do let me know if any of this should be un-done or done differently (code style, etc.) and I'll be happy to update the branch accordingly.

Edit: updated scope of changes