### PR TITLE
Dev small fixes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ bug reports and code to this ntp docker project:
 
  - Chris Turra       => https://github.com/cturra
  - Clément Péron     => https://github.com/clementperon
+ - Nicolas Carrier   => https://github.com/ncarrier
  - Nicolas Innocenti => https://github.com/nicoinn
  - Richard Coleman   => https://github.com/microbug
  - Simon Rupf        => https://github.com/simonrupf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Supported Architectures:
 
-Architectures officially supported by this Docker container:
+Architectures officially supported by this Docker container
 
 ![Linux x86-64](https://img.shields.io/badge/linux/amd64-yellowgreen)
 ![ARMv8 64-bit](https://img.shields.io/badge/linux/arm64-yellowgreen)
@@ -37,7 +37,6 @@ $> docker run --name=ntp            \
               --restart=always      \
               --detach              \
               --publish=123:123/udp \
-              --cap-add=SYS_TIME    \
               cturra/ntp
 
 # OR run ntp with higher security (default behaviour of run.sh and docker-compose).
@@ -45,7 +44,6 @@ $> docker run --name=ntp                           \
               --restart=always                     \
               --detach                             \
               --publish=123:123/udp                \
-              --cap-add=SYS_TIME                   \
               --read-only                          \
               --tmpfs=/etc/chrony:rw,mode=1750     \
               --tmpfs=/run/chrony:rw,mode=1750     \

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -4,6 +4,7 @@ DEFAULT_NTP="time.cloudflare.com"
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 
 # update permissions on chrony directories
+mkdir -p /run/chrony
 chown -R chrony:chrony /run/chrony /var/lib/chrony
 chmod o-rx /run/chrony
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -3,13 +3,18 @@
 DEFAULT_NTP="time.cloudflare.com"
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 
-# update permissions on chrony directories
-mkdir -p /run/chrony
-chown -R chrony:chrony /run/chrony /var/lib/chrony
-chmod o-rx /run/chrony
+# confirm correct permissions on chrony run directory
+if [ -d /run/chrony ]; then
+  chown -R chrony:chrony /run/chrony
+  chmod o-rx /run/chrony
+  # remove previous pid file if it exist
+  rm -f /var/run/chrony/chronyd.pid
+fi
 
-# remove previous pid file if it exist
-rm -f /var/run/chrony/chronyd.pid
+# confirm correct permissions on chrony variable state directory
+if [ -d /var/lib/chrony ]; then
+  chown -R chrony:chrony /var/lib/chrony
+fi
 
 ## dynamically populate chrony config file.
 {

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -43,4 +43,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -d -s
+exec /usr/sbin/chronyd -d -s -x

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -48,4 +48,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -d -s -x
+exec /usr/sbin/chronyd -d -x

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     restart: always
     ports:
       - 123:123/udp
-    cap_add:
-      - SYS_TIME
     read_only: true
     tmpfs:
       - /etc/chrony:rw,mode=1750

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,6 @@ function start_container() {
               --restart=always                     \
               --publish=123:123/udp                \
               --env=NTP_SERVERS=${NTP_SERVERS}     \
-              --cap-add=SYS_TIME                   \
               --read-only=true                     \
               --tmpfs=/etc/chrony:rw,mode=1750     \
               --tmpfs=/run/chrony:rw,mode=1750     \


### PR DESCRIPTION
Hello,
These are small fixes I made when trying to use your docker-ntp docker container.

So first of all, thank you for your work :)

The first fix is minor, there are chmod/own commands made on a directory, /run/chrony, which doesn't exist leading to (harmless) error messages.
The second one is that, when ran with `docker compose up...` as instructed, chronyd fails to run in the container because it doesn't have the permission do issue an adjtimex syscall, so I've added the `-x` flag.
I don't think that having chronyd setting the system clock is really desirable in this context, but it I'm mistaken, I'll be glad to work on a more versatile patch allowing to choose whether or not, the `-x` flag has to be passed.

FTR, I'm using debian 10 as the host system and docker 20.10.2.