### PR TITLE
updates to multiarch build to support buildx upgrade

### DIFF
--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -6,9 +6,14 @@ source vars
 DOCKER=$(which docker)
 BUILD_INST=${CONTAINER_NAME}"-builder"
 
+# check for dry-run flag
+if [ "$1" == "--dry-run" ]; then
+  DRY_RUN=true
+fi
+
 ## requirements:
 # - docker buildx plugin (https://docs.docker.com/buildx/working-with-buildx/)
-if [[ ! -f ~/.docker/cli-plugins/buildx ]]; then
+if [ ! -f ~/.docker/cli-plugins/docker-buildx ]; then
   echo "[ERROR] docker buildx plugin not found!"
   echo "        => https://github.com/docker/buildx/"
   exit 1
@@ -24,7 +29,19 @@ else
 
   # finally, let's build the ntp container
   $DOCKER buildx use ${BUILD_INST}
-  $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
-                       --tag ${IMAGE_NAME} \
-                       --push .
+
+  # check for dry run. if true, build but do not push image to registry
+  if [ "$DRY_RUN" = true ]; then
+    $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
+                         --tag ${IMAGE_NAME} .
+    echo "!! DRY RUN ONLY. NO IMAGE PUSHED TO REGISTRY !!"
+
+  else
+    $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
+                         --tag ${IMAGE_NAME} \
+                         --push .
+  fi
+
+  # clean up build artifacts
+  $DOCKER rm -f $($DOCKER ps --filter "name=buildx_buildkit" --format "{{.ID}}")
 fi


### PR DESCRIPTION
upgraded to buildx 0.5.1, which changed the install directions to naming the cli-plugin `docker-buildx` instead of `buildx`.
additionally, while i was in the file, i added a `--dry-run` flag to ensure there was a safe way to test building locally without
pushing images to registry.