### PR TITLE
Build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM alpine:latest
 
+ARG BUILD_DATE
+
+# first, a bit about this container
+LABEL build_info="cturra/docker-ntp build-date:- ${BUILD_DATE}"
+LABEL maintainer="Chris Turra <cturra@gmail.com>"
+LABEL documentation="https://github.com/cturra/docker-ntp"
+
 # install chrony
 RUN apk add --no-cache chrony
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-## Supported Architectures:
-
-Architectures officially supported by this Docker container
-
-![Linux x86-64](https://img.shields.io/badge/linux/amd64-yellowgreen)
-![ARMv8 64-bit](https://img.shields.io/badge/linux/arm64-yellowgreen)
-![IBM POWER8](https://img.shields.io/badge/linux/ppc64le-yellowgreen)
-![IBM Z Systems](https://img.shields.io/badge/linux/s390x-yellowgreen)
-![Linux x86/i686](https://img.shields.io/badge/linux/386-yellowgreen)
-![ARMv7 32-bit](https://img.shields.io/badge/linux/arm/v7-yellowgreen)
-![ARMv6 32-bit](https://img.shields.io/badge/linux/arm/v6-yellowgreen)
-
-
 ## About this container
 
-[![Docker Build Status](https://img.shields.io/docker/build/cturra/ntp.svg)](https://hub.docker.com/r/cturra/ntp/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/cturra/ntp.svg)](https://hub.docker.com/r/cturra/ntp/)
-[![Apache licensed](https://img.shields.io/badge/license-Apache-blue.svg)](https://raw.githubusercontent.com/cturra/docker-ntp/master/LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/cturra/ntp.svg?logo=docker&label=pulls&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://hub.docker.com/r/cturra/ntp/)
+[![Docker Stars](https://img.shields.io/docker/stars/cturra/ntp.svg?logo=docker&label=stars&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://hub.docker.com/r/cturra/ntp/)
+[![GitHub Stars](https://img.shields.io/github/stars/cturra/docker-ntp.svg?logo=github&label=stars&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://github.com/cturra/docker-ntp)
+[![Apache licensed](https://img.shields.io/badge/license-Apache-blue.svg?logo=apache&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://raw.githubusercontent.com/cturra/docker-ntp/master/LICENSE)
 
-This container runs [chrony](https://chrony.tuxfamily.org/) on [Alpine Linux](https://alpinelinux.org/). More about chrony can be found at:
+This container runs [chrony](https://chrony.tuxfamily.org/) on [Alpine Linux](https://alpinelinux.org/).
 
- * https://chrony.tuxfamily.org/
+[chrony](https://chrony.tuxfamily.org) is a versatile implementation of the Network Time Protocol (NTP). It can synchronise the system clock with NTP servers, reference clocks (e.g. GPS receiver), and manual input using wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) server and peer to provide a time service to other computers in the network.
+
+
+## Supported Architectures
+
+Architectures officially supported by this Docker container. Simply pulling this container from [Docker Hub](https://hub.docker.com/r/cturra/ntp) should retrieve the correct image for your architecture.
+
+![Linux x86-64](https://img.shields.io/badge/linux/amd64-green?style=flat-square)
+![ARMv8 64-bit](https://img.shields.io/badge/linux/arm64-green?style=flat-square)
+![IBM POWER8](https://img.shields.io/badge/linux/ppc64le-green?style=flat-square)
+![IBM Z Systems](https://img.shields.io/badge/linux/s390x-green?style=flat-square)
+![Linux x86/i686](https://img.shields.io/badge/linux/386-green?style=flat-squareg)
+![ARMv7 32-bit](https://img.shields.io/badge/linux/arm/v7-green?style=flat-square)
+![ARMv6 32-bit](https://img.shields.io/badge/linux/arm/v6-green?style=flat-square)
 
 
 ## How to Run this container
 
-### Running from Docker Hub
+### With the Docker CLI
 
 Pull and run -- it's this simple.
 
@@ -52,7 +53,7 @@ $> docker run --name=ntp                           \
 ```
 
 
-### Building and Running with Docker Compose
+### With Docker Compose
 
 Using the docker-compose.yml file included in this git repo, you can build the container yourself (should you choose to).
 *Note: this docker-compose files uses the `3.4` compose format, which requires Docker Engine release 17.09.0+
@@ -72,7 +73,7 @@ $> docker-compose logs ntp
 ```
 
 
-### Building and Running with Docker Engine
+### From a CLI
 
 Using the vars file in this git repo, you can update any of the variables to reflect your
 environment. Once updated, simply execute the build then run scripts.

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -5,11 +5,20 @@ source vars
 
 DOCKER=$(which docker)
 BUILD_INST=${CONTAINER_NAME}"-builder"
+BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
 
-# check for dry-run flag
-if [ "$1" == "--dry-run" ]; then
-  DRY_RUN=true
+# MODE options:
+#  - dry_run: (default) build images, but DO NOT push to dockerhub
+#  - go_time: build and push all images
+MODE="DRY_RUN"
+
+if [ "$#" -gt 0 ]; then
+  # argument supplied. check if it's "go time"
+  if [ "$1" == "--go-time" ]; then
+    MODE="GO_TIME"
+  fi
 fi
+
 
 ## requirements:
 # - docker buildx plugin (https://docs.docker.com/buildx/working-with-buildx/)
@@ -20,8 +29,8 @@ if [ ! -f ~/.docker/cli-plugins/docker-buildx ]; then
 
 else
   # check if build instance (BUILD_INST) is present
-  $DOCKER buildx ls | grep ${BUILD_INST} 2>&1 /dev/null
-  if [ $? -eq 1 ]; then
+  BUILDER_CHECK=$($DOCKER buildx ls| grep ${BUILD_INST})
+  if [ ! -n "$BUILDER_CHECK" ]; then
     # not found. let's create it
     $DOCKER run --rm --privileged multiarch/qemu-user-static --reset -p yes
     $DOCKER buildx create --name ${BUILD_INST} --driver docker-container --use
@@ -31,14 +40,16 @@ else
   $DOCKER buildx use ${BUILD_INST}
 
   # check for dry run. if true, build but do not push image to registry
-  if [ "$DRY_RUN" = true ]; then
+  if [ "${MODE}" == "DRY_RUN" ]; then
     $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
+                         --build-arg BUILD_DATE=${BUILD_DATE}                                                             \
                          --tag ${IMAGE_NAME} .
     echo "!! DRY RUN ONLY. NO IMAGE PUSHED TO REGISTRY !!"
 
   else
     $DOCKER buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 \
-                         --tag ${IMAGE_NAME} \
+                         --build-arg BUILD_DATE=${BUILD_DATE}                                                             \
+                         --tag ${IMAGE_NAME}                                                                              \
                          --push .
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@
 source vars
 
 DOCKER=$(which docker)
+BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
 
 # build image
-$DOCKER build --pull --tag ${IMAGE_NAME} .
+$DOCKER build --pull                               \
+              --tag ${IMAGE_NAME}                  \
+              --build-arg BUILD_DATE=${BUILD_DATE} \
+              .


### PR DESCRIPTION
introduced a `BUILD_DATE` argument which populates a build_info  container label to give folks a little more information about when the cturra/ntp image they're running was built. additional maintainer and documentation lables also created since i was poking at labels.

to implement this, minor changes were needed to the build scripts, so while in there, i decided to make `--dry-run` the default build argument. it now only pushes to dockerhub if `--go-live` is explicity invoked. #safetyfirst!