### PR TITLE
[feature] 🎉 now running as non-root user 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com
 NTP_SERVERS="ntp1.aliyun.com,ntp2.aliyun.com,ntp3.aliyun.com,ntp4.aliyun.com"
 ```
 
+If you're interested in a public list of stratum 1 servers, you can have a look at the following list.
+Do make sure to verify the ntp server is active as this list does appaer to have some no longer active
+servers.
+
+ * https://www.advtimesync.com/docs/manual/stratum1.html
+
 
 ## Testing your NTP Container
 
@@ -179,6 +185,23 @@ time.cloudflare.com        35  18  139m     +0.014      0.141   -662us   530us
 time1.google.com           33  13  128m     -0.007      0.138   +318us   460us
 ```
 
+
+Are you seeing messages like these and wondering what is going on?
+```
+$ docker logs -f ntps
+[...]
+2021-05-25T18:41:40Z System clock wrong by -2.535004 seconds
+2021-05-25T18:41:40Z Could not step system clock
+2021-05-25T18:42:47Z System clock wrong by -2.541034 seconds
+2021-05-25T18:42:47Z Could not step system clock
+```
+
+Good question! Since `chronyd` is running with the `-x` flag, it will not try to control
+the system (container host) clock. This of course is necessary because the process does not
+have priviledge (for good reason) to modify the clock on the system.
+
+Like any host on your network, simply use your preferred ntp client to pull the time from
+the running ntp container on your container host.
 
 ---
 <a href="https://www.buymeacoffee.com/cturra" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-yellow.png" alt="Buy Me A Coffee" height="41" width="174"></a>

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -40,6 +40,7 @@ done
 
 # final bits for the config file
 {
+  echo
   echo "driftfile /var/lib/chrony/chrony.drift"
   echo "makestep 0.1 3"
   echo "rtcsync"
@@ -48,4 +49,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -d -x
+exec /usr/sbin/chronyd -u chrony -d -x


### PR DESCRIPTION
this is something i've been meaning to do for a while... we all know that it's not the best security practices to run processes in a container as root. this update configured chrony to drop privileges after startup (-u user).

after you launch the container, you can now see the chronyd process (pid 1) running as the chrony user:

```
$> docker exec -ti ntp ps
PID   USER     TIME  COMMAND
  1 chrony    0:00 /usr/sbin/chronyd -u chrony -d -x
619 root      0:00 ps
```

ref: https://chrony.tuxfamily.org/doc/4.0/chronyd.html