### PR TITLE
Ability to provide log level for chronyd

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -32,6 +32,10 @@ if [ -z "${NTP_SERVERS}" ]; then
   NTP_SERVERS="${DEFAULT_NTP}"
 fi
 
+if [ -z "${LOGLEVEL}" ]; then
+  LOGLEVEL=0 # Levels supported 0 (informational), 1 (warning), 2 (non-fatal error), and 3 (fatal error)
+fi
+
 IFS=","
 for N in $NTP_SERVERS; do
   # strip any quotes found before or after ntp server
@@ -49,4 +53,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -u chrony -d -x
+exec /usr/sbin/chronyd -u chrony -d -x -L $LOGLEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - /var/lib/chrony:rw,mode=1750
     environment:
       - NTP_SERVERS=time.cloudflare.com
+      - LOGLEVEL=0


### PR DESCRIPTION
Hi Chris,
Thank you for your hard work and the amazing tool!

I made a small change to have the ability to provide log level to Chronyd. 
I collect logs from my server to be analyzed and want to avoid informational messages from chronyd.

It would really help me this is available on your main build.

Best,
Guru



