### PR TITLE
Ability to provide log level for chronyd

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ bug reports and code to this ntp docker project:
 
  - Chris Turra       => https://github.com/cturra
  - Clément Péron     => https://github.com/clementperon
+ - Guru Govindan     => https://github.com/ggovindan
  - Nicolas Carrier   => https://github.com/ncarrier
  - Nicolas Innocenti => https://github.com/nicoinn
  - Richard Coleman   => https://github.com/microbug

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ servers.
  * https://www.advtimesync.com/docs/manual/stratum1.html
 
 
+## Logging
+
+By default, this project logs informational messages to stdout, which can be helpful when running the
+ntp service. If you'd like to change the level of log verbosity, pass the `LOG_LEVEL` environment
+variable to the container, specifying the level (`#`) when you first start it. This option matches
+the chrony `-L` option, which support the following levels can to specified: 0 (informational), 1
+(warning), 2 (non-fatal error), and 3 (fatal error).
+
+Feel free to check out the project documentation for more information at:
+
+ * https://chrony.tuxfamily.org/doc/4.1/chronyd.html
+
+
 ## Testing your NTP Container
 
 From any machine that has `ntpdate` you can query your new NTP container with the follow

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -32,8 +32,16 @@ if [ -z "${NTP_SERVERS}" ]; then
   NTP_SERVERS="${DEFAULT_NTP}"
 fi
 
-if [ -z "${LOGLEVEL}" ]; then
-  LOGLEVEL=0 # Levels supported 0 (informational), 1 (warning), 2 (non-fatal error), and 3 (fatal error)
+# LOG_LEVEL environment variable is not present, so populate with chrony default (0)
+# chrony log levels: 0 (informational), 1 (warning), 2 (non-fatal error) and 3 (fatal error)
+if [ -z "${LOG_LEVEL}" ]; then
+  LOG_LEVEL=0
+else
+  # confirm log level is between 0-3, since these are the only log levels supported
+  if [ "${LOG_LEVEL}" -gt 3 ]; then
+    # level outside of supported range, let's set to default (0)
+    LOG_LEVEL=0
+  fi
 fi
 
 IFS=","
@@ -53,4 +61,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -u chrony -d -x -L $LOGLEVEL
+exec /usr/sbin/chronyd -u chrony -d -x -L ${LOG_LEVEL}

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -32,6 +32,10 @@ if [ -z "${NTP_SERVERS}" ]; then
   NTP_SERVERS="${DEFAULT_NTP}"
 fi
 
+if [ -z "${LOGLEVEL}" ]; then
+  LOGLEVEL=0 # Levels supported 0 (informational), 1 (warning), 2 (non-fatal error), and 3 (fatal error)
+fi
+
 IFS=","
 for N in $NTP_SERVERS; do
   # strip any quotes found before or after ntp server
@@ -49,4 +53,4 @@ done
 } >> ${CHRONY_CONF_FILE}
 
 ## startup chronyd in the foreground
-exec /usr/sbin/chronyd -u chrony -d -x
+exec /usr/sbin/chronyd -u chrony -d -x -L $LOGLEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       - /var/lib/chrony:rw,mode=1750
     environment:
       - NTP_SERVERS=time.cloudflare.com
-      - LOGLEVEL=0
+      - LOG_LEVEL=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - /var/lib/chrony:rw,mode=1750
     environment:
       - NTP_SERVERS=time.cloudflare.com
+      - LOGLEVEL=0

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ function start_container() {
               --restart=always                     \
               --publish=123:123/udp                \
               --env=NTP_SERVERS=${NTP_SERVERS}     \
+              --env=LOG_LEVEL=${LOG_LEVEL}         \
               --read-only=true                     \
               --tmpfs=/etc/chrony:rw,mode=1750     \
               --tmpfs=/run/chrony:rw,mode=1750     \

--- a/vars
+++ b/vars
@@ -13,5 +13,10 @@ CONTAINER_NAME="ntp"
 # NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com"
 NTP_SERVERS="time.cloudflare.com"
 
+# (optional) define chrony log level to use
+# default: 0
+# options: 0 (informational), 1 (warning), 2 (non-fatal error), and 3 (fatal error)
+LOG_LEVEL=0
+
 # (optional) additional docker run options you may want
 DOCKER_OPTS=""


### PR DESCRIPTION
this pull request is a following up on [PR #42](https://github.com/cturra/docker-ntp/pull/42) since there were a couple additional changes i wanted to make (and didnt have upstream permissions to push them to the `spotai:guru/provide_loglevel_as_docker_option` repo.

original text:
> Hi Chris,
> Thank you for your hard work and the amazing tool!
>
> I made a small change to have the ability to provide log level to Chronyd.
> I collect logs from my server to be analyzed and want to avoid informational messages from chronyd.
>
> It would really help me this is available on your main build.
>
> Best,
> Guru