### PR TITLE
Commented fifth line about build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   ntp:
-    build: .
+#    build: .
     image: cturra/ntp:latest
     container_name: ntp
     restart: always


### PR DESCRIPTION
I was unable to have the container start with `docker-compose up -d` without commenting this fifth line.