### PR TITLE
adding support for local (offline) time server configuration

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ bug reports and code to this ntp docker project:
 
  - Chris Turra       => https://github.com/cturra
  - Clément Péron     => https://github.com/clementperon
+ - Fakuivan          => https://github.com/fakuivan
  - Guru Govindan     => https://github.com/ggovindan
  - Nicolas Carrier   => https://github.com/ncarrier
  - Nicolas Innocenti => https://github.com/nicoinn

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com
 
 # alibaba
 NTP_SERVERS="ntp1.aliyun.com,ntp2.aliyun.com,ntp3.aliyun.com,ntp4.aliyun.com"
+
+# local (offline)
+NTP_SERVER="127.127.1.1"
 ```
 
 If you're interested in a public list of stratum 1 servers, you can have a look at the following list.

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -47,7 +47,18 @@ fi
 IFS=","
 for N in $NTP_SERVERS; do
   # strip any quotes found before or after ntp server
-  echo "server "${N//\"}" iburst" >> ${CHRONY_CONF_FILE}
+  N_CLEANED=${N//\"}
+
+  # check if ntp server has a 127.0.0.0/8 address (RFC3330) indicating it's
+  # the local system clock
+  if [[ "${N_CLEANED}" == *"127\."* ]]; then
+    echo "server "${N_CLEANED} >> ${CHRONY_CONF_FILE}
+    echo "local stratum 10"    >> ${CHRONY_CONF_FILE}
+
+  # found external time servers
+  else
+    echo "server "${N_CLEANED}" iburst" >> ${CHRONY_CONF_FILE}
+  fi
 done
 
 # final bits for the config file


### PR DESCRIPTION
as suggested by @fakuivan i've added a check to the startup script looking for local (offline) time servers based on 127.0.0.0/8 address space. if one is found, the correct configuration is written for local support.