### PR TITLE
adding noclientlog option and minor bug fixes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ bug reports and code to this ntp docker project:
  - Chris Turra       => https://github.com/cturra
  - Clément Péron     => https://github.com/clementperon
  - Fakuivan          => https://github.com/fakuivan
+ - Gontier-Julien    => https://github.com/Gontier-Julien
  - Guru Govindan     => https://github.com/ggovindan
  - Nicolas Carrier   => https://github.com/ncarrier
  - Nicolas Innocenti => https://github.com/nicoinn

--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ servers.
  * https://www.advtimesync.com/docs/manual/stratum1.html
 
 
+## Chronyd Options
+
+### No Client Log (noclientlog)
+
+This is optional and not enabled by default. If you provide the `NOCLIENTLOG=true` envivonrment variable,
+chrony will be configured to:
+
+> Specifies that client accesses are not to be logged. Normally they are logged, allowing statistics to
+> be reported using the clients command in chronyc. This option also effectively disables server support
+> for the NTP interleaved mode.
+
+
 ## Logging
 
 By default, this project logs informational messages to stdout, which can be helpful when running the

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -51,7 +51,7 @@ for N in $NTP_SERVERS; do
 
   # check if ntp server has a 127.0.0.0/8 address (RFC3330) indicating it's
   # the local system clock
-  if [[ "${N_CLEANED}" == *"127\."* ]]; then
+  if [[ "${N_CLEANED}" == "127\."* ]]; then
     echo "server "${N_CLEANED} >> ${CHRONY_CONF_FILE}
     echo "local stratum 10"    >> ${CHRONY_CONF_FILE}
 
@@ -66,7 +66,9 @@ done
   echo
   echo "driftfile /var/lib/chrony/chrony.drift"
   echo "makestep 0.1 3"
-  echo "rtcsync"
+  if [ "${NOCLIENTLOG}" = true ]; then
+    echo "noclientlog"
+  fi
   echo
   echo "allow all"
 } >> ${CHRONY_CONF_FILE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
     environment:
       - NTP_SERVERS=time.cloudflare.com
       - LOG_LEVEL=0
+#     - NOCLIENTLOG=true

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ function start_container() {
               --restart=always                     \
               --publish=123:123/udp                \
               --env=NTP_SERVERS=${NTP_SERVERS}     \
+	      --env=NOCLIENTLOG=${NOCLIENTLOG}     \
               --env=LOG_LEVEL=${LOG_LEVEL}         \
               --read-only=true                     \
               --tmpfs=/etc/chrony:rw,mode=1750     \

--- a/vars
+++ b/vars
@@ -13,6 +13,9 @@ CONTAINER_NAME="ntp"
 # NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com"
 NTP_SERVERS="time.cloudflare.com"
 
+# (optional) turn on noclientlog option
+NOCLIENTLOG=false
+
 # (optional) define chrony log level to use
 # default: 0
 # options: 0 (informational), 1 (warning), 2 (non-fatal error), and 3 (fatal error)


### PR DESCRIPTION
as requested by @Gontier-Julien, i have added the ability to set the `noclientlog` config option via an environment variable.

additionally, the `rtcsync` option is being removed since this container has no access to the system clock so it's not needed.

finally, i addressed a small bug in the local timeserver check.  it previously would have matches on any IP address that contained127 in the 1-3 octets. which is not what we want... it needs to match 127.0/8