### PR TITLE
Added CHRONY_EXTRA option for additional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ NTP_SERVERS="ntp1.aliyun.com,ntp2.aliyun.com,ntp3.aliyun.com,ntp4.aliyun.com"
 
 # local (offline)
 NTP_SERVER="127.127.1.1"
+
+# ptp source (pass device to container)
+CHRONY_EXTRA=refclock PHC /dev/ptp0
 ```
 
 If you're interested in a public list of stratum 1 servers, you can have a look at the following list.

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 DEFAULT_NTP="time.cloudflare.com"
+DEFAULT_EXTRA=""
 CHRONY_CONF_FILE="/etc/chrony/chrony.conf"
 
 # confirm correct permissions on chrony run directory
@@ -32,6 +33,11 @@ if [ -z "${NTP_SERVERS}" ]; then
   NTP_SERVERS="${DEFAULT_NTP}"
 fi
 
+# CHRONY_EXTRA environment variable is not present, so populate with default server
+if [ -z "${CHRONY_EXTRA}" ]; then
+  CHRONY_EXTRA="${DEFAULT_EXTRA}"
+fi
+
 # LOG_LEVEL environment variable is not present, so populate with chrony default (0)
 # chrony log levels: 0 (informational), 1 (warning), 2 (non-fatal error) and 3 (fatal error)
 if [ -z "${LOG_LEVEL}" ]; then
@@ -59,6 +65,18 @@ for N in $NTP_SERVERS; do
   else
     echo "server "${N_CLEANED}" iburst" >> ${CHRONY_CONF_FILE}
   fi
+done
+
+{
+  echo
+  echo "# Extra config provided by CHRONY_EXTRA environment variables."
+} >> ${CHRONY_CONF_FILE}
+IFS=","
+for N in $CHRONY_EXTRA; do
+  # strip any quotes found before or after ntp server
+  N_CLEANED=${N//\"}
+
+  echo ${N_CLEANED} >> ${CHRONY_CONF_FILE}
 done
 
 # final bits for the config file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
     restart: always
     ports:
       - 123:123/udp
+#   devices:
+#     - "/dev/ptp0:/dev/ptp0"
     environment:
       - NTP_SERVERS=time.cloudflare.com
       - LOG_LEVEL=0
+#     - CHRONY_EXTRA=refclock PHC /dev/ptp0 offset 0
 #     - NOCLIENTLOG=true

--- a/run.sh
+++ b/run.sh
@@ -17,8 +17,9 @@ function start_container() {
               --restart=always                     \
               --publish=123:123/udp                \
               --env=NTP_SERVERS=${NTP_SERVERS}     \
-	      --env=NOCLIENTLOG=${NOCLIENTLOG}     \
+	            --env=NOCLIENTLOG=${NOCLIENTLOG}     \
               --env=LOG_LEVEL=${LOG_LEVEL}         \
+              --env=CHRONY_EXTRA=${CHRONY_EXTRA}   \
               --read-only=true                     \
               --tmpfs=/etc/chrony:rw,mode=1750     \
               --tmpfs=/run/chrony:rw,mode=1750     \

--- a/vars
+++ b/vars
@@ -23,3 +23,8 @@ LOG_LEVEL=0
 
 # (optional) additional docker run options you may want
 DOCKER_OPTS=""
+
+# (optional) define additional chrony config
+# Each line must: be comma deliminated
+# CHRONY_EXTRA="# Set reference clock to PTP source,refclock PHC /dev/ptp0 offset 0"
+CHRONY_EXTRA=""


### PR DESCRIPTION
This feature allows special chrony configurations to be added.

Such as having a PTP reference clock and using docker-ntp to serve to ntp clients