### PR TITLE
Add tzdata package to fix unknown timezones

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,15 +1,16 @@
 The following awesome folks have contributed ideas,
 bug reports and code to this ntp docker project:
 
- - Chris Turra       => https://github.com/cturra
- - Clément Péron     => https://github.com/clementperon
- - Fakuivan          => https://github.com/fakuivan
- - Gontier-Julien    => https://github.com/Gontier-Julien
- - Guru Govindan     => https://github.com/ggovindan
- - Nicolas Carrier   => https://github.com/ncarrier
- - Nicolas Innocenti => https://github.com/nicoinn
- - Richard Coleman   => https://github.com/microbug
- - Simon Rupf        => https://github.com/simonrupf
+ - Chris Turra         => https://github.com/cturra
+ - Clément Péron       => https://github.com/clementperon
+ - Fakuivan            => https://github.com/fakuivan
+ - Gontier-Julien      => https://github.com/Gontier-Julien
+ - Guru Govindan       => https://github.com/ggovindan
+ - Kim Oliver Drechsel => https://github.com/kimdre
+ - Nicolas Carrier     => https://github.com/ncarrier
+ - Nicolas Innocenti   => https://github.com/nicoinn
+ - Richard Coleman     => https://github.com/microbug
+ - Simon Rupf          => https://github.com/simonrupf
 
 
 Thanks for your contributions!

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Chris Turra <cturra@gmail.com>"
 LABEL documentation="https://github.com/cturra/docker-ntp"
 
 # install chrony
-RUN apk add --no-cache chrony
+RUN apk add --no-cache chrony tzdata
 
 # script to configure/startup chrony (ntp)
 COPY assets/startup.sh /opt/startup.sh

--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ Feel free to check out the project documentation for more information at:
  * https://chrony.tuxfamily.org/doc/4.1/chronyd.html
 
 
+## Setting your timezone
+
+By default the UTC timezone is used, however if you'd like to adjust your NTP server to be running in your
+local timezone, all you need to do is provide a `TZ` environment variable following the standard TZ data format.
+As an example, using `docker-compose.yaml`, that would be look like this if you were located in Vancouver, Canada:
+
+```yaml
+  ...
+  environment:
+    - TZ=America/Vancouver
+    ...
+```
+
+
 ## Testing your NTP Container
 
 From any machine that has `ntpdate` you can query your new NTP container with the follow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,5 @@ services:
     environment:
       - NTP_SERVERS=time.cloudflare.com
       - LOG_LEVEL=0
-#     - NOCLIENTLOG=true
+#      - TZ=America/Vancouver        
+#      - NOCLIENTLOG=true


### PR DESCRIPTION
If a timezone is set in the container (e.g. `TZ: Europe/Berlin`), the containerized system still displays the wrong time (e.g in logs) because it does not know the timezones. By installing the tzdata package, the system knows what time to set for a particular timezone.