### PR TITLE
Adding possibility of specifying listening interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ As an example, using `docker-compose.yaml`, that would be look like this if you 
     ...
 ```
 
+## Listening Interface
+
+In case the docker 'host' network is used, it is possible to select the interface in which the ntp service wil be 
+listening by setting up the variable `LISTENIFACE` and the interface name in `docker-compose.yaml` file:
+
+```yaml
+  ...
+  environment:
+    - LISTENIFACE=eth1
+    ...
+```
 
 ## Testing your NTP Container
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -64,6 +64,9 @@ done
 # final bits for the config file
 {
   echo
+  if [ ! -z ${LISTENIFACE+x} ]
+    echo "binddevice $LISTENIFACE"
+  fi
   echo "driftfile /var/lib/chrony/chrony.drift"
   echo "makestep 0.1 3"
   if [ "${NOCLIENTLOG}" = true ]; then


### PR DESCRIPTION
When docker "host" network is used and the host has more than one interface, it is desirable to select the interface you want ntp to be listening to. 

This small change allows to set a new variable.