### PR TITLE
Adds new variable to allow enabling NTS for all servers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ bug reports and code to this ntp docker project:
  - Nicolas Innocenti   => https://github.com/nicoinn
  - Richard Coleman     => https://github.com/microbug
  - Simon Rupf          => https://github.com/simonrupf
+ - Trenton H           => https://github.com/stumpylog
 
 
 Thanks for your contributions!

--- a/README.md
+++ b/README.md
@@ -158,12 +158,26 @@ Feel free to check out the project documentation for more information at:
 
 By default the UTC timezone is used, however if you'd like to adjust your NTP server to be running in your
 local timezone, all you need to do is provide a `TZ` environment variable following the standard TZ data format.
-As an example, using `docker-compose.yaml`, that would be look like this if you were located in Vancouver, Canada:
+As an example, using `docker-compose.yaml`, that would look like this if you were located in Vancouver, Canada:
 
 ```yaml
   ...
   environment:
     - TZ=America/Vancouver
+    ...
+```
+
+
+## Enable Network Time Security
+
+If **all** the `NTP_SERVERS` you have configured support NTS (Network Time Security) you can pass the `ENABLE_NTS=true`
+option to the container to enable it. As an example, using `docker-compose.yaml`, that would look like this:
+
+```yaml
+  ...
+  environment:
+    - NTP_SERVER=time.cloudflare.com
+    - ENABLE_NTS=true
     ...
 ```
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -57,7 +57,7 @@ for N in $NTP_SERVERS; do
 
   # found external time servers
   else
-    if [[ "${ENABLE_NTS:-no}" = "yes" ]]; then
+    if [[ "${ENABLE_NTS:-false}" = true ]]; then
       echo "server "${N_CLEANED}" iburst nts" >> ${CHRONY_CONF_FILE}
     else
       echo "server "${N_CLEANED}" iburst" >> ${CHRONY_CONF_FILE}
@@ -70,7 +70,7 @@ done
   echo
   echo "driftfile /var/lib/chrony/chrony.drift"
   echo "makestep 0.1 3"
-  if [ "${NOCLIENTLOG}" = true ]; then
+  if [ "${NOCLIENTLOG:-false}" = true ]; then
     echo "noclientlog"
   fi
   echo

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -57,7 +57,11 @@ for N in $NTP_SERVERS; do
 
   # found external time servers
   else
-    echo "server "${N_CLEANED}" iburst" >> ${CHRONY_CONF_FILE}
+    if [[ "${ENABLE_NTS:-no}" = "yes" ]]; then
+      echo "server "${N_CLEANED}" iburst nts" >> ${CHRONY_CONF_FILE}
+    else
+      echo "server "${N_CLEANED}" iburst" >> ${CHRONY_CONF_FILE}
+    fi
   fi
 done
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
     environment:
       - NTP_SERVERS=time.cloudflare.com
       - LOG_LEVEL=0
-#      - TZ=America/Vancouver        
+#      - TZ=America/Vancouver
 #      - NOCLIENTLOG=true
+#      - ENABLE_NTS=true

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ function start_container() {
               --restart=always                     \
               --publish=123:123/udp                \
               --env=NTP_SERVERS=${NTP_SERVERS}     \
+	      --env=ENABLE_NTS=${ENABLE_NTS}       \
 	      --env=NOCLIENTLOG=${NOCLIENTLOG}     \
               --env=LOG_LEVEL=${LOG_LEVEL}         \
               --read-only=true                     \

--- a/vars
+++ b/vars
@@ -13,6 +13,9 @@ CONTAINER_NAME="ntp"
 # NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com"
 NTP_SERVERS="time.cloudflare.com"
 
+# Enable NTS in the chronyd configuration file
+ENABLE_NTS="yes"
+
 # (optional) turn on noclientlog option
 NOCLIENTLOG=false
 

--- a/vars
+++ b/vars
@@ -13,8 +13,8 @@ CONTAINER_NAME="ntp"
 # NTP_SERVERS="time1.google.com,time2.google.com,time3.google.com,time4.google.com"
 NTP_SERVERS="time.cloudflare.com"
 
-# Enable NTS in the chronyd configuration file
-ENABLE_NTS="yes"
+# (optional) enable NTS in the chronyd configuration file
+ENABLE_NTS=false
 
 # (optional) turn on noclientlog option
 NOCLIENTLOG=false


### PR DESCRIPTION
This PR allows users to set ENABLE_NTS=yes to enable NTS for all servers they have defined.  For ease of the addition, it's all or nothing, so all server should support NTS before enabling this option.  For example, Google's NTP does not support [NTS](https://developers.google.com/time/faq#autokey).  If a user does enable it and not all servers support, they should see logs like:

```log
NTS-KE session with 216.239.35.4:4460 (time.google.com) timed out
```


Fixes #58 