### PR TITLE
Adds a new workflow for building the image using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: ci
+
+on:
+  push:
+    tags:
+      # https://semver.org/#spec-item-2
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      # https://semver.org/#spec-item-9
+      - 'v[0-9]+.[0-9]+.[0-9]+-beta.rc[0-9]+'
+    branches:
+      - "main"
+      - "feature/**"
+
+jobs:
+    build-docker-image:
+        name: Build Docker image for ${{ github.ref_name }}
+        runs-on: ubuntu-22.04
+        steps:
+          -
+            name: Check pushing to registries
+            id: enable-push
+            # Only push to Dockerhub from the main repo AND a tag
+            # Otherwise forks would require a Docker Hub account and secrets setup
+            run: |
+              if [[ ${{ github.repository_owner }} == "cturra" ]] && [[ ${{ startsWith(github.ref, 'refs/tags/v') }} == "true" ]] ; then
+                echo "Enabling DockerHub image push"
+                echo "enable=true" >> $GITHUB_OUTPUT
+              else
+                echo "Not pushing to DockerHub"
+                echo "enable=false" >> $GITHUB_OUTPUT
+              fi
+          -
+            name: Gather Docker metadata
+            id: docker-meta
+            uses: docker/metadata-action@v5
+            with:
+              images: |
+                ghcr.io/cturra/ntp
+                name=cturra/ntp
+              tags: |
+                # Tag branches with branch name
+                type=ref,event=branch
+                # Process semver tags
+                # For a tag x.y.z or vX.Y.Z, output an x.y.z and x.y image tag
+                type=semver,pattern={{version}}
+                type=semver,pattern={{major}}.{{minor}}
+          -
+            name: Checkout
+            uses: actions/checkout@v4
+          -
+            name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v3
+          -
+            name: Set up QEMU
+            uses: docker/setup-qemu-action@v3
+            with:
+              platforms: all
+          -
+            name: Login to GitHub Container Registry
+            uses: docker/login-action@v3
+            if: steps.enable-push.outputs.enable == 'true'
+            with:
+              registry: ghcr.io
+              username: ${{ github.actor }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+          -
+            name: Login to Docker Hub
+            uses: docker/login-action@v3
+            # Don't attempt to login is not pushing to Docker Hub
+            if: steps.enable-push.outputs.enable == 'true'
+            with:
+              username: ${{ secrets.DOCKERHUB_USERNAME }}
+              password: ${{ secrets.DOCKERHUB_TOKEN }}
+          -
+            name: Build and push
+            uses: docker/build-push-action@v5
+            with:
+              context: .
+              file: ./Dockerfile
+              platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+              push: ${{ steps.enable-push.outputs.enable }}
+              tags: ${{ steps.docker-meta.outputs.tags }}
+              labels: ${{ steps.docker-meta.outputs.labels }}


### PR DESCRIPTION
This adds a GitHub Actions workflow to build and optionally push the Docker image, using the standard actions, mostly from Docker themselves.

## Features
- Pushes only on the push of a vX.Y.Z tag, builds on pushes to `main` or `feature/*` branches
- [Automatic](https://github.com/stumpylog/docker-ntp/actions/runs/6460715940/job/17538953498#step:3:54) standard labels for the image
- [Automatic image tags](https://github.com/stumpylog/docker-ntp/actions/runs/6460715940/job/17538953498#step:3:46) including allowing users to follow a release series (vX.Y vs vX.Y.Z)
- [Same multi-arch building](https://github.com/stumpylog/docker-ntp/actions/runs/6460715940/job/17538953498#step:6:237)
- No need for build-multiarch.sh anymore, though I kept it for reference