### PR TITLE
 Add support for NTS on the server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ following during startup:
 
 > NTS-KE session with 164.67.62.194:4460 (tick.ucla.edu) timed out
 
-To enable NTS within the chronyd server for clients, you can provide an SSL certificate and matching private key with the `NTS_CRT` and `NTS_KEY` options, respectively:
+To enable NTS within the chronyd server for clients, you can provide the path to an SSL certificate and matching private key (both in PEM format) with the `NTS_CRT` and `NTS_KEY` options, respectively:
 
 ```yaml
   ...

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ following during startup:
 
 > NTS-KE session with 164.67.62.194:4460 (tick.ucla.edu) timed out
 
+To enable NTS within the chronyd server for clients, you can provide an SSL certificate and matching private key with the `NTS_CRT` and `NTS_KEY` options, respectively:
+
+```yaml
+  ...
+  environment:
+    - NTS_CRT="/path/to/ssl.crt"
+    - NTS_KEY="/path/to/private.key"
+```
 
 ## Testing your NTP Container
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -65,6 +65,20 @@ for N in $NTP_SERVERS; do
   fi
 done
 
+# Enable NTS server if vars present
+if [ "${NTS_CRT:+1}${NTS_KEY:+1}" == 1 ]; then
+  # Only one variable was provided, when either both or none are required
+  # Exit with error due to invalid config
+  echo -e "ERROR: Both 'NTS_CRT' & 'NTS_KEY' are required vars when enabling NTS for chronyd. Currently have:\n* NTS_CRT=${NTS_CRT}\n* NTS_KEY=${NTS_KEY}"
+  exit 1
+fi
+
+if [ "${NTS_CRT:+1}${NTS_KEY:+1}" == 11 ]; then
+  # Both vars present, so inject into config
+  echo "ntsservercert ${NTS_CRT}" >> ${CHRONY_CONF_FILE}
+  echo "ntsserverkey ${NTS_KEY}" >> ${CHRONY_CONF_FILE}
+fi
+
 # final bits for the config file
 {
   echo

--- a/vars
+++ b/vars
@@ -16,6 +16,10 @@ NTP_SERVERS="time.cloudflare.com"
 # (optional) enable NTS in the chronyd configuration file
 ENABLE_NTS=false
 
+# (optional) provide SSL and key to enable NTS server in chronyd
+NTS_CRT=""
+NTS_KEY=""
+
 # (optional) turn on noclientlog option
 NOCLIENTLOG=false
 


### PR DESCRIPTION
Hello! This PR is just to add two vars that will allow the chronyd daemon to serve as an NTS server on the default port of 4460. I tested this and found out that all the bits to support NTS were already present, it just needed the ability to add the variables in.

There's actually a number of NTS-related configs that can go into `chrony.conf`, but seeings that this projects goal is to be a "simple" NTP container, and that chrony can operate with defaults on everything else, I've only included vars for the two configs necessary to actually enable NTP - `ntsservercert` & `ntsserverkey`.

Let me know what you think!