### PR TITLE
Update links to Chrony project

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ bug reports and code to this ntp docker project:
 
  - Chris Turra         => https://github.com/cturra
  - Clément Péron       => https://github.com/clementperon
+ - Fabian Wünderich    => https://github.com/fanonwue
  - Fakuivan            => https://github.com/fakuivan
  - Gontier-Julien      => https://github.com/Gontier-Julien
  - Guru Govindan       => https://github.com/ggovindan

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![GitHub Stars](https://img.shields.io/github/stars/cturra/docker-ntp.svg?logo=github&label=stars&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://github.com/cturra/docker-ntp)
 [![Apache licensed](https://img.shields.io/badge/license-Apache-blue.svg?logo=apache&style=for-the-badge&color=0099ff&logoColor=ffffff)](https://raw.githubusercontent.com/cturra/docker-ntp/master/LICENSE)
 
-This container runs [chrony](https://chrony.tuxfamily.org/) on [Alpine Linux](https://alpinelinux.org/).
+This container runs [chrony](https://chrony-project.org/) on [Alpine Linux](https://alpinelinux.org/).
 
-[chrony](https://chrony.tuxfamily.org) is a versatile implementation of the Network Time Protocol (NTP). It can synchronise the system clock with NTP servers, reference clocks (e.g. GPS receiver), and manual input using wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) server and peer to provide a time service to other computers in the network.
+[chrony](https://chrony-project.org/) is a versatile implementation of the Network Time Protocol (NTP). It can synchronise the system clock with NTP servers, reference clocks (e.g. GPS receiver), and manual input using wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) server and peer to provide a time service to other computers in the network.
 
 
 ## Supported Architectures
@@ -151,7 +151,7 @@ the chrony `-L` option, which support the following levels can to specified: 0 (
 
 Feel free to check out the project documentation for more information at:
 
- * https://chrony.tuxfamily.org/doc/4.1/chronyd.html
+ * https://chrony-project.org/doc/4.1/chronyd.html
 
 
 ## Setting your timezone

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ the chrony `-L` option, which support the following levels can to specified: 0 (
 
 Feel free to check out the project documentation for more information at:
 
- * https://chrony-project.org/doc/4.1/chronyd.html
+ * https://chrony-project.org/documentation.html
 
 
 ## Setting your timezone


### PR DESCRIPTION
The chrony project has moved their project page / documentation to a new URL, the old one is no longer available.

It's referenced in the official README as well: https://gitlab.com/chrony/chrony/-/blob/master/README